### PR TITLE
Use helper to construct URL for letter index

### DIFF
--- a/includes/civicrm-directory-browse.php
+++ b/includes/civicrm-directory-browse.php
@@ -248,7 +248,7 @@ class CiviCRM_Directory_Browse {
 		foreach( $chars AS $char ) {
 
 			// set href
-			$href = $url . '/?civicrm_directory_first_letter=' . $char;
+			$href = add_query_arg( 'civicrm_directory_first_letter', $char, $url );
 
 			// maybe set additional class
 			$class = '';


### PR DESCRIPTION
The letter index was generating links with two question marks when I first tried out the plugin on an empty site before changing the permalink from the default.